### PR TITLE
Fix retrieval time order

### DIFF
--- a/app/api/retrieval-time/[target_id]/route.ts
+++ b/app/api/retrieval-time/[target_id]/route.ts
@@ -14,7 +14,7 @@ export async function GET(
   const result = await database.retrievalTime.findFirst({
     select: { duration: true },
     where: { targetId: context.params.target_id },
-    orderBy: { createdAt: 'desc' },
+    orderBy: { duration: 'desc' },
   });
 
   if (result === null) return Response.json({ duration: null });


### PR DESCRIPTION
Retrieval time order should ordered by duration rather than created_at to get the longest duration